### PR TITLE
Fix Cadence errors and refactor shared types

### DIFF
--- a/contracts/FlowWager.cdc
+++ b/contracts/FlowWager.cdc
@@ -1,8 +1,8 @@
-import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS
-import FlowToken from 0xFLOW_TOKEN_ADDRESS
+import FungibleToken from "FungibleToken"
+import FlowToken from "FlowToken"
+import FlowWagerTypes from "./FlowWagerTypes.cdc" // Import the new types contract
 
-// TODO: Replace 0xFUNGIBLE_TOKEN_ADDRESS and 0xFLOW_TOKEN_ADDRESS
-// with actual addresses during deployment (e.g., from flow.json).
+// Imports are now named and will be resolved by flow.json
 
 // TODO: Uncomment imports when contracts are used and paths are confirmed.
 // import FlowWagerEvents from "./FlowWagerEvents.cdc"
@@ -10,39 +10,18 @@ import FlowToken from 0xFLOW_TOKEN_ADDRESS
 
 access(all) contract FlowWager {
 
-    access(all) enum MarketCategory: UInt8 {
-        case Sports = 0
-        case Politics = 1
-        case Cryptocurrency = 2
-        case Economics = 3
-        case Entertainment = 4
-        case Technology = 5
-        case Science = 6
-        case Lifestyle = 7
-        case Weather = 8
-        case Gaming = 9
-        case Other = 10
-        case Meta = 11 // For markets about FlowWager itself
-    }
-
-    access(all) enum MarketStatus: UInt8 {
-        case Active = 0
-        case PendingResolution = 1
-        case Resolved = 2
-        case Cancelled = 3
-        case EmergencyResolved = 4
-    }
+    // MarketCategory and MarketStatus enums are now in FlowWagerTypes
 
     access(all) resource Market {
         access(all) let id: UInt64
         access(all) let title: String
         access(all) let description: String
-        access(all) let category: MarketCategory
+        access(all) let category: FlowWagerTypes.MarketCategory // Updated type
         access(all) let creator: Address
         access(all) let creationTime: UFix64
         access(all) let endTime: UFix64
         access(all) let options: [String]
-        access(all) var status: MarketStatus
+        access(all) var status: FlowWagerTypes.MarketStatus // Updated type
         access(all) var outcome: String?
         access(all) var evidenceURL: String?
         access(all) var resolutionTimestamp: UFix64?
@@ -56,7 +35,7 @@ access(all) contract FlowWager {
             id: UInt64,
             title: String,
             description: String,
-            category: MarketCategory,
+            category: FlowWagerTypes.MarketCategory, // Updated type
             creator: Address,
             creationTime: UFix64,
             endTime: UFix64,
@@ -79,7 +58,7 @@ access(all) contract FlowWager {
             self.creationTime = creationTime
             self.endTime = endTime
             self.options = options
-            self.status = MarketStatus.Active
+            self.status = FlowWagerTypes.MarketStatus.Active // Updated type
             self.outcome = nil
             self.evidenceURL = nil
             self.resolutionTimestamp = nil
@@ -98,7 +77,7 @@ access(all) contract FlowWager {
         access(all) fun placePrediction(predictor: Address, option: String, amount: UFix64) {
             // TODO: Integrate FlowWagerSecurity.validateBetAmount(amount)
             pre {
-                self.status == MarketStatus.Active: "Market is not active"
+                self.status == FlowWagerTypes.MarketStatus.Active: "Market is not active"
                 getCurrentBlock().timestamp < self.endTime: "Market has ended"
                 self.options.contains(option): "Invalid option provided"
                 amount > 0.0: "Prediction amount must be positive"
@@ -122,13 +101,13 @@ access(all) contract FlowWager {
 
         access(contract) fun internalResolve(outcome: String, evidenceURL: String, resolver: Address) {
             pre {
-                self.status == MarketStatus.PendingResolution || self.status == MarketStatus.Active : "Market is not in a resolvable state"
+                self.status == FlowWagerTypes.MarketStatus.PendingResolution || self.status == FlowWagerTypes.MarketStatus.Active : "Market is not in a resolvable state"
                 self.options.contains(outcome): "Invalid outcome for this market"
                 evidenceURL.length > 0 : "Evidence URL cannot be empty"
             }
             self.outcome = outcome
             self.evidenceURL = evidenceURL
-            self.status = MarketStatus.Resolved
+            self.status = FlowWagerTypes.MarketStatus.Resolved
             self.resolutionTimestamp = getCurrentBlock().timestamp
             // TODO: Emit MarketResolved event
         }
@@ -140,14 +119,14 @@ access(all) contract FlowWager {
             }
             self.outcome = outcome
             self.evidenceURL = evidenceURL
-            self.status = MarketStatus.EmergencyResolved
+            self.status = FlowWagerTypes.MarketStatus.EmergencyResolved
             self.resolutionTimestamp = getCurrentBlock().timestamp
             // TODO: Emit MarketEmergencyResolution event
         }
 
         access(all) fun getUserWinnings(user: Address): UFix64 {
             pre {
-                self.status == MarketStatus.Resolved || self.status == MarketStatus.EmergencyResolved : "Market is not yet resolved"
+                self.status == FlowWagerTypes.MarketStatus.Resolved || self.status == FlowWagerTypes.MarketStatus.EmergencyResolved : "Market is not yet resolved"
                 self.outcome != nil : "Market outcome is not set"
             }
 
@@ -175,7 +154,7 @@ access(all) contract FlowWager {
         }
 
         access(all) fun canEnableEmergencyResolution(): Bool {
-            return self.status == MarketStatus.PendingResolution && (getCurrentBlock().timestamp > (self.endTime + FlowWager.RESOLUTION_WINDOW))
+            return self.status == FlowWagerTypes.MarketStatus.PendingResolution && (getCurrentBlock().timestamp > (self.endTime + FlowWager.RESOLUTION_WINDOW))
         }
 
         access(all) fun getMarketInfo(): {String: AnyStruct} {
@@ -210,8 +189,8 @@ access(all) contract FlowWager {
         }
 
         access(all) fun trySetToPendingResolution() {
-            if self.status == MarketStatus.Active && getCurrentBlock().timestamp >= self.endTime {
-                self.status = MarketStatus.PendingResolution
+            if self.status == FlowWagerTypes.MarketStatus.Active && getCurrentBlock().timestamp >= self.endTime {
+                self.status = FlowWagerTypes.MarketStatus.PendingResolution
                 // TODO: Emit MarketStatusUpdated event
             }
         }
@@ -301,7 +280,7 @@ access(all) contract FlowWager {
     ): UInt64 {
         // TODO: Integrate FlowWagerSecurity validation
         pre {
-            MarketCategory.fromRawValue(category) != nil : "Invalid market category"
+            FlowWagerTypes.MarketCategory(rawValue: category) != nil : "Invalid market category"
         }
 
         let marketCreator = payment.owner!.address
@@ -314,7 +293,7 @@ access(all) contract FlowWager {
              platformVaultRef.deposit(from: <-feeVault)
         }
 
-        let marketCategory = MarketCategory.fromRawValue(category) ?? panic("Invalid category raw value")
+        let marketCategory = FlowWagerTypes.MarketCategory(rawValue: category) ?? panic("Invalid category raw value")
 
         let marketId = self.nextMarketId
         let newMarket <- create Market(
@@ -365,11 +344,11 @@ access(all) contract FlowWager {
 
         let market = self.markets[marketId]!
 
-        if market.status == MarketStatus.Active && getCurrentBlock().timestamp >= market.endTime {
+        if market.status == FlowWagerTypes.MarketStatus.Active && getCurrentBlock().timestamp >= market.endTime {
              market.trySetToPendingResolution()
         }
 
-        assert(market.status == MarketStatus.PendingResolution, message: "Market is not yet pending resolution.")
+        assert(market.status == FlowWagerTypes.MarketStatus.PendingResolution, message: "Market is not yet pending resolution.")
 
         market.internalResolve(outcome: outcome, evidenceURL: evidenceURL, resolver: adminCapRef.adminAddress)
         // Note: Fee distribution to creator is a TODO.
@@ -387,7 +366,7 @@ access(all) contract FlowWager {
             self.markets[marketId] != nil : "Market not found"
         }
         let market = self.markets[marketId]!
-        assert(market.status == MarketStatus.Resolved || market.status == MarketStatus.EmergencyResolved, message: "Market is not resolved yet.")
+        assert(market.status == FlowWagerTypes.MarketStatus.Resolved || market.status == FlowWagerTypes.MarketStatus.EmergencyResolved, message: "Market is not resolved yet.")
         assert(market.outcome != nil, message: "Market outcome is not set.")
 
         let winningsAmount = market.getUserWinnings(user: userAddress)
@@ -451,7 +430,7 @@ access(all) contract FlowWager {
             adminCapRef.hasPermission(permission: "emergency_resolve") : "Admin does not have permission for emergency resolution." // TODO: Define this permission
         }
         let market = self.markets[marketId]!
-        assert(market.status == MarketStatus.PendingResolution || market.status == MarketStatus.Active, "Market is not in a state that can be emergency resolved.")
+        assert(market.status == FlowWagerTypes.MarketStatus.PendingResolution || market.status == FlowWagerTypes.MarketStatus.Active, "Market is not in a state that can be emergency resolved.")
         assert(getCurrentBlock().timestamp >= market.endTime, "Emergency resolution typically used for markets past their end time.")
 
         market.internalEmergencyResolve(outcome: outcome, evidenceURL: evidenceURL, resolver: adminCapRef.adminAddress)
@@ -476,10 +455,8 @@ access(all) contract FlowWager {
     }
 
     access(all) fun getMarket(marketId: UInt64): {String: AnyStruct}? {
+        // Removed market.trySetToPendingResolution() - should be handled by a transaction
         if let market = self.markets[marketId] {
-            if market.status == MarketStatus.Active && getCurrentBlock().timestamp >= market.endTime {
-                 market.trySetToPendingResolution()
-            }
             return market.getMarketInfo()
         }
         return nil
@@ -489,6 +466,7 @@ access(all) contract FlowWager {
         let allMarketInfos: [{String: AnyStruct}] = []
         let marketIds = self.markets.keys
         for id in marketIds {
+            // getMarket no longer mutates, so this is safe.
             if let marketInfo = self.getMarket(marketId: id) {
                  allMarketInfos.append(marketInfo)
             }
@@ -497,15 +475,13 @@ access(all) contract FlowWager {
     }
 
     access(all) fun getMarketsByCategory(category: UInt8): [{String: AnyStruct}] {
-        let categoryEnum = MarketCategory.fromRawValue(category) ?? panic("Invalid category raw value")
+        let categoryEnum = FlowWagerTypes.MarketCategory(rawValue: category) ?? panic("Invalid category raw value")
         let filteredMarketInfos: [{String: AnyStruct}] = []
         let marketIds = self.markets.keys
         for id in marketIds {
             let market = self.markets[id]!
             if market.category == categoryEnum {
-                if market.status == MarketStatus.Active && getCurrentBlock().timestamp >= market.endTime {
-                    market.trySetToPendingResolution()
-                }
+                // Removed market.trySetToPendingResolution()
                 filteredMarketInfos.append(market.getMarketInfo())
             }
         }
@@ -513,15 +489,8 @@ access(all) contract FlowWager {
     }
 
     access(all) fun getMarketsByStatus(status: UInt8): [{String: AnyStruct}] {
-        let statusEnum = MarketStatus.fromRawValue(status) ?? panic("Invalid status raw value")
-        if statusEnum == MarketStatus.Active || statusEnum == MarketStatus.PendingResolution {
-            for key in self.markets.keys {
-                let market = self.markets[key]!
-                if market.status == MarketStatus.Active && getCurrentBlock().timestamp >= market.endTime {
-                    market.trySetToPendingResolution()
-                }
-            }
-        }
+        let statusEnum = FlowWagerTypes.MarketStatus(rawValue: status) ?? panic("Invalid status raw value")
+        // Removed loop that called market.trySetToPendingResolution()
 
         let filteredMarketInfos: [{String: AnyStruct}] = []
         let marketIds = self.markets.keys
@@ -550,16 +519,14 @@ access(all) contract FlowWager {
 
         for key in self.markets.keys {
             let market = self.markets[key]!
-            if market.status == MarketStatus.Active && getCurrentBlock().timestamp >= market.endTime {
-                market.trySetToPendingResolution()
-            }
+            // Removed market.trySetToPendingResolution()
 
             totalMarkets = totalMarkets + 1
             totalVolumeAcrossAllMarkets = totalVolumeAcrossAllMarkets + market.totalPool
 
-            if market.status == MarketStatus.Active { activeMarkets = activeMarkets + 1 }
-            else if market.status == MarketStatus.PendingResolution { pendingResolutionMarkets = pendingResolutionMarkets + 1 }
-            else if market.status == MarketStatus.Resolved || market.status == MarketStatus.EmergencyResolved { resolvedMarkets = resolvedMarkets + 1 }
+            if market.status == FlowWagerTypes.MarketStatus.Active { activeMarkets = activeMarkets + 1 }
+            else if market.status == FlowWagerTypes.MarketStatus.PendingResolution { pendingResolutionMarkets = pendingResolutionMarkets + 1 }
+            else if market.status == FlowWagerTypes.MarketStatus.Resolved || market.status == FlowWagerTypes.MarketStatus.EmergencyResolved { resolvedMarkets = resolvedMarkets + 1 }
         }
 
         return {

--- a/contracts/FlowWagerAdmin.cdc
+++ b/contracts/FlowWagerAdmin.cdc
@@ -119,8 +119,13 @@ access(all) contract FlowWagerAdmin {
 
     access(all) fun validateEvidence(evidence: Evidence): Bool {
         // Basic URL format check; more robust validation can be in FlowWagerSecurity
-        // Assuming String.startsWith is available
-        if !evidence.url.startsWith("http://") && !evidence.url.startsWith("https://") {
+        let httpPrefix = "http://"
+        let httpsPrefix = "https://"
+        let url = evidence.url
+        let startsWithHttp = url.length >= httpPrefix.length && url.slice(from: 0, upTo: httpPrefix.length) == httpPrefix
+        let startsWithHttps = url.length >= httpsPrefix.length && url.slice(from: 0, upTo: httpsPrefix.length) == httpsPrefix
+
+        if !startsWithHttp && !startsWithHttps {
             log("Evidence validation failed: URL format invalid for evidence related to market ".concat(evidence.marketId.toString()))
             return false
         }

--- a/contracts/FlowWagerMarkets.cdc
+++ b/contracts/FlowWagerMarkets.cdc
@@ -1,16 +1,12 @@
 // FlowWagerMarkets.cdc
 // Purpose: Advanced market management, analytics, and creator statistics for FlowWager
 
-import FlowWager from "./FlowWager.cdc" // Import the main FlowWager contract
+import FlowWager from "FlowWager" // Import the main FlowWager contract, resolved by flow.json
+import FlowWagerTypes from "./FlowWagerTypes.cdc" // Import the shared types
+import MarketDataProvider from "./MarketDataProvider.cdc" // Import the interface
 
-// This interface represents what FlowWagerMarkets expects the FlowWager contract to provide.
-// FlowWager contract would need to implement this interface and publish a capability to it.
-access(all) contract interface MarketDataProvider {
-    access(all) fun getAllMarketDataViews(): [FlowWagerMarkets.MarketDataView]
-    access(all) fun getMarketDataView(marketId: UInt64): FlowWagerMarkets.MarketDataView?
-    access(all) fun getCreatorTotalEarnings(creatorAddress: Address): UFix64
-    // TODO: Ensure FlowWager.cdc has a public capability path for this interface, e.g., /public/FlowWagerMarketDataProvider
-}
+// MarketDataProvider interface is now in its own file.
+// MarketDataView struct is now in FlowWagerTypes.cdc
 
 access(all) contract FlowWagerMarkets {
 
@@ -24,7 +20,7 @@ access(all) contract FlowWagerMarkets {
         access(all) let createdAt: UFix64
         access(all) let endedAt: UFix64
         access(all) let resolvedAt: UFix64?
-        access(all) let category: UInt8
+        access(all) let category: UInt8 // This is FlowWagerTypes.MarketCategory.rawValue
         access(all) let creator: Address
         access(all) let resolutionTime: UFix64?
 
@@ -79,42 +75,22 @@ access(all) contract FlowWagerMarkets {
         }
     }
 
-    // Used by MarketDataProvider interface in FlowWager.cdc
-    access(all) struct MarketDataView {
-        access(all) let id: UInt64
-        access(all) let totalPool: UFix64
-        access(all) let participantCount: UInt64
-        access(all) let totalPredictionsCount: UInt64 // TODO: Ensure FlowWager.Market tracks this
-        access(all) let creationTime: UFix64
-        access(all) let endTime: UFix64
-        access(all) let resolutionTimestamp: UFix64?
-        access(all) let category: FlowWager.MarketCategory
-        access(all) let creator: Address
-        access(all) let status: FlowWager.MarketStatus
+    // MarketDataView struct is now defined in FlowWagerTypes.cdc
 
-        init(id: UInt64, totalPool: UFix64, participantCount: UInt64, totalPredictionsCount: UInt64,
-             creationTime: UFix64, endTime: UFix64, resolutionTimestamp: UFix64?,
-             category: FlowWager.MarketCategory, creator: Address, status: FlowWager.MarketStatus) {
-            self.id = id
-            self.totalPool = totalPool
-            self.participantCount = participantCount
-            self.totalPredictionsCount = totalPredictionsCount
-            self.creationTime = creationTime
-            self.endTime = endTime
-            self.resolutionTimestamp = resolutionTimestamp
-            self.category = category
-            self.creator = creator
-            self.status = status
-        }
+    // Local struct for sorting markets by volume, used in getMarketsByVolume
+    access(all) struct MarketVol {
+        access(all) let id: UInt64
+        access(all) let volume: UFix64
+        init(id: UInt64, volume: UFix64) { self.id = id; self.volume = volume }
     }
 
     access(all) let flowWagerContractAddress: Address
     // Define the public capability path where FlowWager is expected to publish its MarketDataProvider capability.
     access(all) let marketDataProviderPublicPath: PublicPath
 
-    access(all) fun getMarketDataProvider(): &{MarketDataProvider} {
+    access(all) fun getMarketDataProvider(): &{MarketDataProvider.MarketDataProvider} {
         return getAccount(self.flowWagerContractAddress)
-            .capabilities.borrow<&{MarketDataProvider}>(self.marketDataProviderPublicPath)
+            .capabilities.borrow<&{MarketDataProvider.MarketDataProvider}>(self.marketDataProviderPublicPath)
             ?? panic("Could not borrow MarketDataProvider capability from FlowWager contract. Ensure it's published.")
     }
 
@@ -144,7 +120,7 @@ access(all) contract FlowWagerMarkets {
             if mv.creator == creatorAddress {
                 marketsCreatedCount = marketsCreatedCount + 1
                 totalVolumeGenerated = totalVolumeGenerated + mv.totalPool
-                if mv.status == FlowWager.MarketStatus.Resolved || mv.status == FlowWager.MarketStatus.EmergencyResolved {
+                if mv.status == FlowWagerTypes.MarketStatus.Resolved || mv.status == FlowWagerTypes.MarketStatus.EmergencyResolved {
                     resolvedMarketsCount = resolvedMarketsCount + 1
                     if mv.resolutionTimestamp != nil && mv.endTime < mv.resolutionTimestamp! {
                         totalResolutionDurationForResolved = totalResolutionDurationForResolved + (mv.resolutionTimestamp! - mv.endTime)
@@ -214,8 +190,8 @@ access(all) contract FlowWagerMarkets {
             let categoryRaw = mv.category.rawValue
             if categoryData[categoryRaw] == nil {
                 categoryData[categoryRaw] = {
-                    "category": categoryRaw, "totalMarkets": UInt64(0), "totalVolume": 0.0,
-                    "totalParticipants": UInt64(0), "activeMarkets": UInt64(0)
+                    "category": categoryRaw, "totalMarkets": 0 as UInt64, "totalVolume": 0.0,
+                    "totalParticipants": 0 as UInt64, "activeMarkets": 0 as UInt64
                 }
             }
 
@@ -223,7 +199,7 @@ access(all) contract FlowWagerMarkets {
             currentData["totalMarkets"] = (currentData["totalMarkets"] as! UInt64) + 1
             currentData["totalVolume"] = (currentData["totalVolume"] as! UFix64) + mv.totalPool
             currentData["totalParticipants"] = (currentData["totalParticipants"] as! UInt64) + mv.participantCount
-            if mv.status == FlowWager.MarketStatus.Active {
+            if mv.status == FlowWagerTypes.MarketStatus.Active {
                  currentData["activeMarkets"] = (currentData["activeMarkets"] as! UInt64) + 1
             }
             categoryData[categoryRaw] = currentData
@@ -236,11 +212,7 @@ access(all) contract FlowWagerMarkets {
         let provider = self.getMarketDataProvider()
         let allMarketViews = provider.getAllMarketDataViews()
 
-        struct MarketVol { // Local struct for sorting
-            access(all) let id: UInt64
-            access(all) let volume: UFix64
-            init(id: UInt64, volume: UFix64) { self.id = id; self.volume = volume }
-        }
+        // MarketVol struct is now defined at the contract level
         var marketsWithVol: [MarketVol] = []
         for mv in allMarketViews { marketsWithVol.append(MarketVol(id: mv.id, volume: mv.totalPool)) }
 
@@ -273,8 +245,8 @@ access(all) contract FlowWagerMarkets {
         for mv in allMarketViews {
             totalMarkets = totalMarkets + 1
             totalPlatformVolume = totalPlatformVolume + mv.totalPool
-            if mv.status == FlowWager.MarketStatus.Active { activeMarkets = activeMarkets + 1 }
-            else if mv.status == FlowWager.MarketStatus.Resolved || mv.status == FlowWager.MarketStatus.EmergencyResolved { resolvedMarkets = resolvedMarkets + 1 }
+            if mv.status == FlowWagerTypes.MarketStatus.Active { activeMarkets = activeMarkets + 1 }
+            else if mv.status == FlowWagerTypes.MarketStatus.Resolved || mv.status == FlowWagerTypes.MarketStatus.EmergencyResolved { resolvedMarkets = resolvedMarkets + 1 }
         }
 
         return {

--- a/contracts/FlowWagerSecurity.cdc
+++ b/contracts/FlowWagerSecurity.cdc
@@ -61,8 +61,13 @@ access(all) contract FlowWagerSecurity {
         if url.length == 0 {
             return false
         }
-        // Assuming String.startsWith is available in Cadence 1.0
-        if !url.startsWith("http://") && !url.startsWith("https://") {
+        let httpPrefix = "http://"
+        let httpsPrefix = "https://"
+        // Basic URL format check
+        let startsWithHttp = url.length >= httpPrefix.length && url.slice(from: 0, upTo: httpPrefix.length) == httpPrefix
+        let startsWithHttps = url.length >= httpsPrefix.length && url.slice(from: 0, upTo: httpsPrefix.length) == httpsPrefix
+
+        if !startsWithHttp && !startsWithHttps {
             return false
         }
         if url.length > 512 {

--- a/contracts/FlowWagerTypes.cdc
+++ b/contracts/FlowWagerTypes.cdc
@@ -1,0 +1,72 @@
+// FlowWagerTypes.cdc
+// This contract defines shared enums and structs for the FlowWager ecosystem.
+
+access(all) contract FlowWagerTypes {
+
+    access(all) enum MarketCategory: UInt8 {
+        case Sports = 0
+        case Politics = 1
+        case Cryptocurrency = 2
+        case Economics = 3
+        case Entertainment = 4
+        case Technology = 5
+        case Science = 6
+        case Lifestyle = 7
+        case Weather = 8
+        case Gaming = 9
+        case Other = 10
+        case Meta = 11 // For markets about FlowWager itself
+    }
+
+    access(all) enum MarketStatus: UInt8 {
+        case Active = 0
+        case PendingResolution = 1
+        case Resolved = 2
+        case Cancelled = 3
+        case EmergencyResolved = 4
+    }
+
+    // MarketDataView struct, previously in FlowWagerMarkets.cdc
+    // Now references MarketCategory and MarketStatus from this FlowWagerTypes contract.
+    access(all) struct MarketDataView {
+        access(all) let id: UInt64
+        access(all) let totalPool: UFix64
+        access(all) let participantCount: UInt64
+        access(all) let totalPredictionsCount: UInt64
+        access(all) let creationTime: UFix64
+        access(all) let endTime: UFix64
+        access(all) let resolutionTimestamp: UFix64?
+        access(all) let category: MarketCategory // Now refers to FlowWagerTypes.MarketCategory
+        access(all) let creator: Address
+        access(all) let status: MarketStatus   // Now refers to FlowWagerTypes.MarketStatus
+
+        init(
+            id: UInt64,
+            totalPool: UFix64,
+            participantCount: UInt64,
+            totalPredictionsCount: UInt64,
+            creationTime: UFix64,
+            endTime: UFix64,
+            resolutionTimestamp: UFix64?,
+            category: MarketCategory, // Parameter type also updated
+            creator: Address,
+            status: MarketStatus // Parameter type also updated
+        ) {
+            self.id = id
+            self.totalPool = totalPool
+            self.participantCount = participantCount
+            self.totalPredictionsCount = totalPredictionsCount
+            self.creationTime = creationTime
+            self.endTime = endTime
+            self.resolutionTimestamp = resolutionTimestamp
+            self.category = category
+            self.creator = creator
+            self.status = status
+        }
+    }
+
+    // Note: FlowWagerTypes contract itself doesn't have an init() function
+    // as it's primarily a container for type definitions.
+    // If it were to hold state, an init() would be needed.
+    // For just types, Cadence allows contracts without init.
+}

--- a/contracts/MarketDataProvider.cdc
+++ b/contracts/MarketDataProvider.cdc
@@ -1,0 +1,12 @@
+// MarketDataProvider.cdc
+// This interface represents what FlowWagerMarkets expects the FlowWager contract to provide.
+
+// Import FlowWagerTypes to access the MarketDataView struct.
+import FlowWagerTypes from "./FlowWagerTypes.cdc"
+
+access(all) contract interface MarketDataProvider {
+    access(all) fun getAllMarketDataViews(): [FlowWagerTypes.MarketDataView]
+    access(all) fun getMarketDataView(marketId: UInt64): FlowWagerTypes.MarketDataView?
+    access(all) fun getCreatorTotalEarnings(creatorAddress: Address): UFix64
+    // TODO: Ensure FlowWager.cdc has a public capability path for this interface, e.g., /public/FlowWagerMarketDataProvider
+}

--- a/flow.json
+++ b/flow.json
@@ -1,5 +1,4 @@
 {
-  "version": "1.8.0",
   "contracts": {
     "FungibleToken": {
       "source": "./cadence/contracts/standard/FungibleToken.cdc",
@@ -37,7 +36,8 @@
     "FlowWagerSecurity": "./contracts/FlowWagerSecurity.cdc",
     "FlowWagerAdmin": "./contracts/FlowWagerAdmin.cdc",
     "FlowWager": "./contracts/FlowWager.cdc",
-    "FlowWagerMarkets": "./contracts/FlowWagerMarkets.cdc"
+    "FlowWagerMarkets": "./contracts/FlowWagerMarkets.cdc",
+    "FlowWagerTypes": "./contracts/FlowWagerTypes.cdc"
   },
   "networks": {
     "emulator": "127.0.0.1:3569",
@@ -58,53 +58,6 @@
       "key": "YOUR_MAINNET_ACCOUNT_PRIVATE_KEY_ (USE_ENV_VARIABLE_RECOMMENDED)"
     }
   },
-  "aliases": {
-    "FUNGIBLE_TOKEN_ADDRESS": {
-        "emulator": "0xee82856bf20e2aa6",
-        "testnet": "0x9a0766d93b6608b7",
-        "mainnet": "0xf233dcee88fe0abe"
-    },
-    "FLOW_TOKEN_ADDRESS": {
-        "emulator": "0x0ae53cb6e3f42a79",
-        "testnet": "0x7e60df042a9c0868",
-        "mainnet": "0x1654653399040a61"
-    },
-    "NON_FUNGIBLE_TOKEN_ADDRESS": {
-        "emulator": "0x631e88ae7f1d7c20",
-        "testnet": "0x631e88ae7f1d7c20",
-        "mainnet": "0x1d7e57aa55817448"
-    },
-    "METADATA_VIEWS_ADDRESS": {
-        "emulator": "0x631e88ae7f1d7c20",
-        "testnet": "0x631e88ae7f1d7c20",
-        "mainnet": "0x1d7e57aa55817448"
-    },
-    "FLOWWAGER_EVENTS_ADDRESS": {
-        "emulator": "0xf8d6e0586b0a20c7",
-        "testnet": "YOUR_TESTNET_ACCOUNT_ADDRESS",
-        "mainnet": "YOUR_MAINNET_ACCOUNT_ADDRESS"
-    },
-    "FLOWWAGER_SECURITY_ADDRESS": {
-        "emulator": "0xf8d6e0586b0a20c7",
-        "testnet": "YOUR_TESTNET_ACCOUNT_ADDRESS",
-        "mainnet": "YOUR_MAINNET_ACCOUNT_ADDRESS"
-    },
-    "FLOWWAGER_ADMIN_ADDRESS": {
-        "emulator": "0xf8d6e0586b0a20c7",
-        "testnet": "YOUR_TESTNET_ACCOUNT_ADDRESS",
-        "mainnet": "YOUR_MAINNET_ACCOUNT_ADDRESS"
-    },
-    "FLOWWAGER_ADDRESS": {
-        "emulator": "0xf8d6e0586b0a20c7",
-        "testnet": "YOUR_TESTNET_ACCOUNT_ADDRESS",
-        "mainnet": "YOUR_MAINNET_ACCOUNT_ADDRESS"
-    },
-    "FLOWWAGER_MARKETS_ADDRESS": {
-        "emulator": "0xf8d6e0586b0a20c7",
-        "testnet": "YOUR_TESTNET_ACCOUNT_ADDRESS",
-        "mainnet": "YOUR_MAINNET_ACCOUNT_ADDRESS"
-    }
-  },
   "deployments": {
     "emulator": {
       "emulator-account": [
@@ -112,6 +65,7 @@
         "FlowToken",
         "NonFungibleToken",
         "MetadataViews",
+        "FlowWagerTypes", // Deploy types first
         "FlowWagerEvents",
         "FlowWagerSecurity",
         "FlowWagerAdmin",

--- a/scripts/get_admin_status.cdc
+++ b/scripts/get_admin_status.cdc
@@ -1,6 +1,6 @@
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFLOWWAGER_ADDRESS with actual deployment address or flow.json alias.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Script to check if an address is an admin and retrieve their permissions.

--- a/scripts/get_all_markets.cdc
+++ b/scripts/get_all_markets.cdc
@@ -1,6 +1,6 @@
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFLOWWAGER_ADDRESS with actual deployment address or flow.json alias.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Script to get a list of all markets with their detailed information.

--- a/scripts/get_creator_stats.cdc
+++ b/scripts/get_creator_stats.cdc
@@ -1,5 +1,5 @@
-import FlowWagerMarkets from 0xFLOWWAGER_MARKETS_ADDRESS
-// TODO: Replace 0xFLOWWAGER_MARKETS_ADDRESS with actual deployment address or flow.json alias.
+import FlowWagerMarkets from "FlowWagerMarkets"
+// Imports are now named and will be resolved by flow.json
 // This script also assumes FlowWagerMarkets has been correctly initialized with the
 // address of the FlowWager contract and the public path to its MarketDataProvider capability.
 

--- a/scripts/get_market.cdc
+++ b/scripts/get_market.cdc
@@ -1,6 +1,6 @@
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFLOWWAGER_ADDRESS with actual deployment address or flow.json alias.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Script to get detailed information about a specific market.

--- a/scripts/get_market_analytics.cdc
+++ b/scripts/get_market_analytics.cdc
@@ -1,5 +1,5 @@
-import FlowWagerMarkets from 0xFLOWWAGER_MARKETS_CONTRACT_ADDRESS
-// TODO: Replace 0xFLOWWAGER_MARKETS_CONTRACT_ADDRESS with actual deployment address.
+import FlowWagerMarkets from "FlowWagerMarkets"
+// Imports are now named and will be resolved by flow.json
 // This also implies that FlowWagerMarkets contract is deployed and initialized.
 
 /*

--- a/scripts/get_markets_by_category.cdc
+++ b/scripts/get_markets_by_category.cdc
@@ -1,6 +1,6 @@
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFLOWWAGER_ADDRESS with actual deployment address or flow.json alias.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Script to get a list of markets filtered by a specific category.

--- a/scripts/get_markets_by_status.cdc
+++ b/scripts/get_markets_by_status.cdc
@@ -1,6 +1,6 @@
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFLOWWAGER_ADDRESS with actual deployment address or flow.json alias.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Script to get a list of markets filtered by a specific status.

--- a/scripts/get_platform_stats.cdc
+++ b/scripts/get_platform_stats.cdc
@@ -1,6 +1,6 @@
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFLOWWAGER_ADDRESS with actual deployment address or flow.json alias.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Script to get overall platform statistics.

--- a/scripts/get_user_predictions.cdc
+++ b/scripts/get_user_predictions.cdc
@@ -1,6 +1,6 @@
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFLOWWAGER_ADDRESS with actual deployment address or flow.json alias.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Script to get all predictions made by a specific user across all markets.

--- a/scripts/get_user_winnings.cdc
+++ b/scripts/get_user_winnings.cdc
@@ -1,6 +1,6 @@
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFLOWWAGER_ADDRESS with actual deployment address or flow.json alias.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Script to calculate a user's potential winnings from a specific resolved market.

--- a/transactions/add_admin.cdc
+++ b/transactions/add_admin.cdc
@@ -1,6 +1,6 @@
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFLOWWAGER_ADDRESS with actual deployment address or flow.json alias.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Transaction for an existing admin to add a new admin.

--- a/transactions/batch_resolve_markets.cdc
+++ b/transactions/batch_resolve_markets.cdc
@@ -1,6 +1,6 @@
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFLOWWAGER_ADDRESS with actual deployment address or flow.json alias.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Transaction for an admin to resolve multiple markets in a batch.

--- a/transactions/claim_winnings.cdc
+++ b/transactions/claim_winnings.cdc
@@ -1,10 +1,9 @@
-import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS
+import FungibleToken from "FungibleToken"
 // FlowToken import might not be strictly needed if only FT interface is used for receiver
-// import FlowToken from 0xFLOW_TOKEN_ADDRESS
-import FlowWager from 0xFLOWWAGER_ADDRESS
+// import FlowToken from "FlowToken" // Keep as named import if uncommented
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFUNGIBLE_TOKEN_ADDRESS, (0xFLOW_TOKEN_ADDRESS if used),
-// and 0xFLOWWAGER_ADDRESS with actual deployment addresses or flow.json aliases.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Transaction for a user to claim their winnings from a resolved market.

--- a/transactions/create_market.cdc
+++ b/transactions/create_market.cdc
@@ -1,9 +1,8 @@
-import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS
-import FlowToken from 0xFLOW_TOKEN_ADDRESS
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FungibleToken from "FungibleToken"
+import FlowToken from "FlowToken"
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFUNGIBLE_TOKEN_ADDRESS, 0xFLOW_TOKEN_ADDRESS,
-// and 0xFLOWWAGER_ADDRESS with actual deployment addresses or flow.json aliases.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Transaction to create a new prediction market.

--- a/transactions/emergency_resolve.cdc
+++ b/transactions/emergency_resolve.cdc
@@ -1,6 +1,6 @@
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFLOWWAGER_ADDRESS with actual deployment address or flow.json alias.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Transaction for an admin to perform an emergency resolution of a market.

--- a/transactions/place_prediction.cdc
+++ b/transactions/place_prediction.cdc
@@ -1,9 +1,8 @@
-import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS
-import FlowToken from 0xFLOW_TOKEN_ADDRESS
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FungibleToken from "FungibleToken"
+import FlowToken from "FlowToken"
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFUNGIBLE_TOKEN_ADDRESS, 0xFLOW_TOKEN_ADDRESS,
-// and 0xFLOWWAGER_ADDRESS with actual deployment addresses or flow.json aliases.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Transaction to place a prediction (bet) on a market.

--- a/transactions/remove_admin.cdc
+++ b/transactions/remove_admin.cdc
@@ -1,6 +1,6 @@
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFLOWWAGER_ADDRESS with actual deployment address or flow.json alias.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Transaction for an existing admin to remove another admin.

--- a/transactions/resolve_market.cdc
+++ b/transactions/resolve_market.cdc
@@ -1,6 +1,6 @@
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFLOWWAGER_ADDRESS with actual deployment address or flow.json alias.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Transaction for an admin to resolve a prediction market.

--- a/transactions/update_market_status.cdc
+++ b/transactions/update_market_status.cdc
@@ -1,6 +1,6 @@
-import FlowWager from 0xFLOWWAGER_ADDRESS
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFLOWWAGER_ADDRESS with actual deployment address or flow.json alias.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Transaction to manually trigger a status update for a market.

--- a/transactions/withdraw_platform_fees.cdc
+++ b/transactions/withdraw_platform_fees.cdc
@@ -1,10 +1,9 @@
-import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS
+import FungibleToken from "FungibleToken"
 // FlowToken import is not strictly necessary if only FungibleToken.Receiver is used.
-// import FlowToken from 0xFLOW_TOKEN_ADDRESS
-import FlowWager from 0xFLOWWAGER_ADDRESS
+// import FlowToken from "FlowToken" // Keep as named import if uncommented
+import FlowWager from "FlowWager"
 
-// TODO: Replace 0xFUNGIBLE_TOKEN_ADDRESS, (0xFLOW_TOKEN_ADDRESS if used),
-// and 0xFLOWWAGER_ADDRESS with actual deployment addresses or flow.json aliases.
+// Imports are now named and will be resolved by flow.json
 
 /*
 Transaction for an admin to withdraw accumulated platform fees.


### PR DESCRIPTION
- Corrected flow.json structure.
- Standardized all Cadence imports to use named imports.
- Created FlowWagerTypes.cdc for shared enums (MarketCategory, MarketStatus) and structs (MarketDataView).
- Updated FlowWager.cdc, FlowWagerMarkets.cdc, and MarketDataProvider.cdc to use FlowWagerTypes.
- Fixed 'startsWith' method errors by using string slicing.
- Resolved various type errors, including enum raw value initialization.
- Addressed 'impure operation in view context' warnings by removing state changes from view functions where appropriate.
- Moved MarketDataProvider interface to its own file.
- Relocated MarketVol struct in FlowWagerMarkets to contract scope.