### PR TITLE
Apply Cadence 1.0 migration fixes and correct import paths

### DIFF
--- a/contracts/FlowWager.cdc
+++ b/contracts/FlowWager.cdc
@@ -1,6 +1,6 @@
 import FungibleToken from "FungibleToken"
 import FlowToken from "FlowToken"
-import FlowWagerTypes from "./FlowWagerTypes.cdc" // Import the new types contract
+import FlowWagerTypes from "FlowWagerTypes" // Import the new types contract by name
 
 // Imports are now named and will be resolved by flow.json
 
@@ -195,9 +195,8 @@ access(all) contract FlowWager {
             }
         }
 
-        destroy() {
-            // TODO: Log destruction if needed
-        }
+        // Custom destructors are removed in Cadence 1.0
+        // Resources are automatically destroyed when they go out of scope.
     }
 
     access(all) resource AdminCapability {
@@ -289,11 +288,11 @@ access(all) contract FlowWager {
              assert(payment.balance >= self.MARKET_CREATION_FEE, message: "Insufficient payment for market creation fee")
              let feeVault <- payment.withdraw(amount: self.MARKET_CREATION_FEE)
              let platformVaultRef = self.account.storage.borrow<&FlowToken.Vault>(from: self.platformVaultPath)
-                ?? panic("Could not borrow platform vault reference")
+                ?? panic(message: "Could not borrow platform vault reference")
              platformVaultRef.deposit(from: <-feeVault)
         }
 
-        let marketCategory = FlowWagerTypes.MarketCategory(rawValue: category) ?? panic("Invalid category raw value")
+        let marketCategory = FlowWagerTypes.MarketCategory(rawValue: category) ?? panic(message: "Invalid category raw value")
 
         let marketId = self.nextMarketId
         let newMarket <- create Market(
@@ -301,13 +300,15 @@ access(all) contract FlowWager {
             creator: marketCreator, creationTime: getCurrentBlock().timestamp, endTime: endTime, options: options
         )
 
-        let oldMarket <- self.markets.insert(key: marketId, <-newMarket)
-        destroy oldMarket
+        let oldMarket: @Market? <- self.markets.insert(key: marketId, <-newMarket)
+        // oldMarket (if non-nil) is implicitly destroyed if not used further. Explicit 'destroy' removed.
 
         self.nextMarketId = self.nextMarketId + 1
 
-        // Passed-in payment vault is consumed.
-        destroy payment
+        // Passed-in payment vault (@FungibleToken.Vault) must be consumed.
+        // If payment vault is not fully depleted by fee withdrawal, remaining tokens are implicitly lost
+        // when 'payment' goes out of scope as it's an owned resource parameter.
+        // Explicit 'destroy payment' removed.
 
         let currentCreatorCount = self.userMarketsCreatedCount[marketCreator] ?? 0
         self.userMarketsCreatedCount[marketCreator] = currentCreatorCount + 1
@@ -321,13 +322,13 @@ access(all) contract FlowWager {
             payment.balance > 0.0 : "Prediction amount must be positive"
             self.markets[marketId] != nil : "Market with the given ID does not exist"
         }
-        let market = self.markets[marketId] ?? panic("Market not found")
+        let market = self.markets[marketId] ?? panic(message: "Market not found")
         let predictor = payment.owner!.address
 
         market.placePrediction(predictor: predictor, option: option, amount: payment.balance)
 
         let platformVaultRef = self.account.storage.borrow<&FlowToken.Vault>(from: self.platformVaultPath)
-            ?? panic("Could not borrow platform vault reference for prediction")
+            ?? panic(message: "Could not borrow platform vault reference for prediction")
         platformVaultRef.deposit(from: <-payment)
 
         let currentPredictorCount = self.userPredictionsPlacedCount[predictor] ?? 0
@@ -388,8 +389,8 @@ access(all) contract FlowWager {
         }
 
         let newAdminCap <- create AdminCapability(adminAddress: adminAddress, permissions: permissions)
-        let oldCap <- self.adminCapabilities.insert(key: adminAddress, <-newAdminCap)
-        destroy oldCap
+        let oldCap: @AdminCapability? <- self.adminCapabilities.insert(key: adminAddress, <-newAdminCap)
+        // oldCap (if non-nil) is implicitly destroyed. Explicit 'destroy' removed.
 
         self.admins[adminAddress] = true
         // TODO: Emit AdminAdded event
@@ -406,8 +407,8 @@ access(all) contract FlowWager {
         }
 
         self.admins.remove(key: adminAddress)
-        let removedCap <- self.adminCapabilities.remove(key: adminAddress)
-        destroy removedCap
+        let removedCap: @AdminCapability? <- self.adminCapabilities.remove(key: adminAddress)
+        // removedCap (if non-nil) is implicitly destroyed. Explicit 'destroy' removed.
         // TODO: Emit AdminRemoved event
         log("Admin removed")
     }
@@ -445,7 +446,7 @@ access(all) contract FlowWager {
         }
 
         let platformVaultRef = self.account.storage.borrow<&FlowToken.Vault>(from: self.platformVaultPath)
-            ?? panic("Could not borrow platform vault reference for fee withdrawal")
+            ?? panic(message: "Could not borrow platform vault reference for fee withdrawal")
 
         assert(platformVaultRef.balance >= amount, message: "Insufficient balance in platform vault.")
 
@@ -475,7 +476,7 @@ access(all) contract FlowWager {
     }
 
     access(all) fun getMarketsByCategory(category: UInt8): [{String: AnyStruct}] {
-        let categoryEnum = FlowWagerTypes.MarketCategory(rawValue: category) ?? panic("Invalid category raw value")
+        let categoryEnum = FlowWagerTypes.MarketCategory(rawValue: category) ?? panic(message: "Invalid category raw value")
         let filteredMarketInfos: [{String: AnyStruct}] = []
         let marketIds = self.markets.keys
         for id in marketIds {
@@ -489,7 +490,7 @@ access(all) contract FlowWager {
     }
 
     access(all) fun getMarketsByStatus(status: UInt8): [{String: AnyStruct}] {
-        let statusEnum = FlowWagerTypes.MarketStatus(rawValue: status) ?? panic("Invalid status raw value")
+        let statusEnum = FlowWagerTypes.MarketStatus(rawValue: status) ?? panic(message: "Invalid status raw value")
         // Removed loop that called market.trySetToPendingResolution()
 
         let filteredMarketInfos: [{String: AnyStruct}] = []
@@ -515,7 +516,7 @@ access(all) contract FlowWager {
         var totalVolumeAcrossAllMarkets = 0.0
 
         let platformVaultRef = self.account.storage.borrow<&FlowToken.Vault>(from: self.platformVaultPath)
-            ?? panic("Could not borrow platform vault reference for stats")
+            ?? panic(message: "Could not borrow platform vault reference for stats")
 
         for key in self.markets.keys {
             let market = self.markets[key]!
@@ -538,7 +539,7 @@ access(all) contract FlowWager {
     }
 
     access(all) fun getUserPredictionsForMarket(marketId: UInt64, userAddress: Address): {String: UFix64}? {
-        let market = self.markets[marketId] ?? panic("Market not found")
+        let market = self.markets[marketId] ?? panic(message: "Market not found")
         if let userPredictions = market.predictions[userAddress] {
             return userPredictions
         }

--- a/contracts/FlowWagerMarkets.cdc
+++ b/contracts/FlowWagerMarkets.cdc
@@ -2,8 +2,8 @@
 // Purpose: Advanced market management, analytics, and creator statistics for FlowWager
 
 import FlowWager from "FlowWager" // Import the main FlowWager contract, resolved by flow.json
-import FlowWagerTypes from "./FlowWagerTypes.cdc" // Import the shared types
-import MarketDataProvider from "./MarketDataProvider.cdc" // Import the interface
+import FlowWagerTypes from "FlowWagerTypes" // Import the shared types by name
+import MarketDataProvider from "MarketDataProvider" // Import the interface by name
 
 // MarketDataProvider interface is now in its own file.
 // MarketDataView struct is now in FlowWagerTypes.cdc

--- a/contracts/FlowWagerTypes.cdc
+++ b/contracts/FlowWagerTypes.cdc
@@ -65,6 +65,18 @@ access(all) contract FlowWagerTypes {
         }
     }
 
+    access(all) struct MarketResolutionInfo {
+        access(all) let marketId: UInt64
+        access(all) let outcome: String
+        access(all) let evidenceURL: String
+
+        init(marketId: UInt64, outcome: String, evidenceURL: String) {
+            self.marketId = marketId
+            self.outcome = outcome
+            self.evidenceURL = evidenceURL
+        }
+    }
+
     // Note: FlowWagerTypes contract itself doesn't have an init() function
     // as it's primarily a container for type definitions.
     // If it were to hold state, an init() would be needed.

--- a/contracts/MarketDataProvider.cdc
+++ b/contracts/MarketDataProvider.cdc
@@ -2,7 +2,7 @@
 // This interface represents what FlowWagerMarkets expects the FlowWager contract to provide.
 
 // Import FlowWagerTypes to access the MarketDataView struct.
-import FlowWagerTypes from "./FlowWagerTypes.cdc"
+import FlowWagerTypes from "FlowWagerTypes" // Import by name
 
 access(all) contract interface MarketDataProvider {
     access(all) fun getAllMarketDataViews(): [FlowWagerTypes.MarketDataView]

--- a/scripts/get_admin_status.cdc
+++ b/scripts/get_admin_status.cdc
@@ -38,8 +38,17 @@ access(all) fun main(adminAddress: Address): {String: AnyStruct} {
 
         log("Address ".concat(adminAddress.toString()).concat(" IS an admin."))
         if permissions != nil {
-            // Cadence 1.0: String array .join is not standard. Manual join or log raw array.
-            log("Permissions (raw): ".concat(permissions!.toString()))
+            var permissionsString = ""
+            let perms = permissions!
+            if perms.length > 0 {
+                permissionsString = perms[0]
+                var i = 1
+                while i < perms.length {
+                    permissionsString = permissionsString.concat(", ").concat(perms[i])
+                    i = i + 1
+                }
+            }
+            log("Permissions: [".concat(permissionsString).concat("]"))
         } else {
             // This case should ideally not happen if isAdmin is true and data is consistent.
             log("Permissions could not be retrieved, though address is marked as admin.")

--- a/scripts/get_market_analytics.cdc
+++ b/scripts/get_market_analytics.cdc
@@ -14,7 +14,7 @@ Returns:
                                       (The MarketAnalytics struct is defined in FlowWagerMarkets.cdc)
 */
 
-pub fun main(marketId: UInt64): FlowWagerMarkets.MarketAnalytics? {
+access(all) fun main(marketId: UInt64): FlowWagerMarkets.MarketAnalytics? {
     // Call the getMarketAnalytics function on the FlowWagerMarkets contract
     let analytics = FlowWagerMarkets.getMarketAnalytics(marketId: marketId)
 

--- a/transactions/add_admin.cdc
+++ b/transactions/add_admin.cdc
@@ -14,11 +14,12 @@ transaction(newAdminAddress: Address, permissions: [String]) {
 
     let callingAdminCapability: &FlowWager.AdminCapability
 
-    prepare(signer: AuthAccount) {
+    prepare(signer: auth(Storage) &Account) {
         // Borrow the calling admin's capability from their account.
         // Assumes admins store their capability at /storage/flowWagerAdminCapability.
+        // Need auth(Storage) to access signer.storage.borrow
         self.callingAdminCapability = signer.storage.borrow<&FlowWager.AdminCapability>(from: /storage/flowWagerAdminCapability)
-            ?? panic("Could not borrow AdminCapability from signer. Ensure you are an admin and the capability is at the correct path.")
+            ?? panic(message: "Could not borrow AdminCapability from signer. Ensure you are an admin and the capability is at the correct path.")
 
         // The FlowWager.addAdmin function itself performs permission checks.
     }
@@ -31,11 +32,21 @@ transaction(newAdminAddress: Address, permissions: [String]) {
         )
 
         log("Admin ".concat(self.callingAdminCapability.adminAddress.toString()).concat(" added new admin: ").concat(newAdminAddress.toString()))
-        log("New admin permissions: ".concat(permissions.join(", "))) // .join might not be available on [String], depends on Cadence version string utils
-                                                                    // If not, log permissions array directly or iterate.
-                                                                    // For Cadence 1.0, String array .join is not standard. Manual join or log raw array.
-        log("Raw permissions array: ".concat(permissions.toString()))
 
+        var permissionsString = ""
+        if permissions.length > 0 {
+            permissionsString = permissions[0]
+            var i = 1
+            while i < permissions.length {
+                permissionsString = permissionsString.concat(", ").concat(permissions[i])
+                i = i + 1
+            }
+        }
+        log("New admin permissions: [".concat(permissionsString).concat("]"))
+        // For raw logging, log(permissions) might work, or iterate and log each element.
+        // The .toString() for direct concatenation with another string is the issue.
+        // Logging the constructed string is clearer.
+        log("Raw permissions array (logged as constructed string): [".concat(permissionsString).concat("]"))
 
         // AdminAdded event is emitted by the FlowWager contract.
         // TODO: Consider if FlowWager.addAdmin should directly call FlowWagerAdmin.logAdminAction.

--- a/transactions/batch_resolve_markets.cdc
+++ b/transactions/batch_resolve_markets.cdc
@@ -1,4 +1,5 @@
 import FlowWager from "FlowWager"
+import FlowWagerTypes from "FlowWagerTypes" // Import for MarketResolutionInfo
 
 // Imports are now named and will be resolved by flow.json
 
@@ -8,17 +9,17 @@ WARNING: Batch operations can be gas-intensive and may hit transaction limits.
 If one resolution fails, the entire batch rolls back.
 
 Parameters:
-- marketResolutions: [{marketId: UInt64, outcome: String, evidenceURL: String}]
+- marketResolutions: [FlowWagerTypes.MarketResolutionInfo]
   An array of structs, each detailing a market to resolve.
 */
 
-transaction(marketResolutions: [{marketId: UInt64, outcome: String, evidenceURL: String}]) {
+transaction(marketResolutions: [FlowWagerTypes.MarketResolutionInfo]) {
 
     let adminCapability: &FlowWager.AdminCapability
 
-    prepare(signer: AuthAccount) {
+    prepare(signer: auth(Storage) &Account) { // Updated for Cadence 1.0
         self.adminCapability = signer.storage.borrow<&FlowWager.AdminCapability>(from: /storage/flowWagerAdminCapability)
-            ?? panic("Could not borrow AdminCapability from signer. Ensure you are an admin and the capability is at the correct path.")
+            ?? panic(message: "Could not borrow AdminCapability from signer. Ensure you are an admin and the capability is at the correct path.")
 
         // FlowWager.resolveMarket (called in loop) checks "resolve_market" permission.
         // A specific "batch_resolve_markets" permission could be added to adminCap for this tx if desired.

--- a/transactions/claim_winnings.cdc
+++ b/transactions/claim_winnings.cdc
@@ -20,11 +20,12 @@ transaction(marketId: UInt64) {
     // this transaction will not function for fund transfer and a different approach is needed.
     // See comments in FlowWager.cdc around claimWinnings function.
 
-    prepare(signer: AuthAccount) {
+    prepare(signer: auth(Capabilities) &Account) {
         // Get the user's FlowToken Receiver capability.
         // Assumes it's published at the standard public path for FlowToken.
+        // Need auth(Capabilities) to access signer.capabilities.borrow
         self.userFlowTokenReceiver = signer.capabilities.borrow<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)
-            ?? panic("Could not borrow Receiver capability from the signer's account. Make sure it's published at /public/flowTokenReceiver.")
+            ?? panic(message: "Could not borrow Receiver capability from the signer's account. Make sure it's published at /public/flowTokenReceiver.")
     }
 
     execute {
@@ -40,7 +41,9 @@ transaction(marketId: UInt64) {
             log("Winnings deposited to signer's account.")
         } else {
             log("No winnings to claim or already claimed for market ID: ".concat(marketId.toString()))
-            destroy claimedVault // Destroy the empty vault
+            // In Cadence 1.0, 'destroy' is removed. Empty vaults are implicitly destroyed.
+            // If claimedVault is an optional that's nil, this branch isn't hit.
+            // If claimedVault is non-nil and empty, it's handled when it goes out of scope.
         }
         // WinningsClaimed event should be emitted by the FlowWager contract if winnings > 0.0
     }

--- a/transactions/create_market.cdc
+++ b/transactions/create_market.cdc
@@ -22,11 +22,11 @@ transaction(title: String, description: String, categoryRawValue: UInt8, endTime
     let paymentVault: @FungibleToken.Vault
     let marketCreator: Address
 
-    prepare(signer: AuthAccount) {
+    prepare(signer: auth(Storage) &Account) {
         self.marketCreator = signer.address
 
         let vaultRef = signer.storage.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)
-            ?? panic("Could not borrow reference to the signer's FlowToken Vault")
+            ?? panic(message: "Could not borrow reference to the signer's FlowToken Vault")
 
         // The FlowWager.createMarket function handles the logic for fee waiver if creator is admin.
         // This transaction prepares a vault with the specified fee amount.

--- a/transactions/emergency_resolve.cdc
+++ b/transactions/emergency_resolve.cdc
@@ -15,11 +15,11 @@ transaction(marketId: UInt64, outcome: String, evidenceURL: String) {
 
     let adminCapability: &FlowWager.AdminCapability
 
-    prepare(signer: AuthAccount) {
+    prepare(signer: auth(Storage) &Account) {
         // Borrow the admin capability from the signer's account.
         // Assumes admins store their capability at /storage/flowWagerAdminCapability.
         self.adminCapability = signer.storage.borrow<&FlowWager.AdminCapability>(from: /storage/flowWagerAdminCapability)
-            ?? panic("Could not borrow AdminCapability from signer. Ensure you are an admin and the capability is at the correct path.")
+            ?? panic(message: "Could not borrow AdminCapability from signer. Ensure you are an admin and the capability is at the correct path.")
 
         // The FlowWager.emergencyResolveMarket function itself performs permission checks.
     }
@@ -33,7 +33,7 @@ transaction(marketId: UInt64, outcome: String, evidenceURL: String) {
         )
 
         log("Market ID: ".concat(marketId.toString()).concat(" EMERGENCY RESOLVED by admin: ").concat(self.adminCapability.adminAddress.toString()))
-        log("Outcome: ".concat(outcome).concat(", Evidence: ".concat(evidenceURL))
+        log("Outcome: ".concat(outcome).concat(", Evidence: ").concat(evidenceURL))
         // MarketEmergencyResolved event is emitted by the FlowWager contract.
         // TODO: Consider if FlowWager.emergencyResolveMarket should call FlowWagerAdmin.logAdminAction.
     }

--- a/transactions/place_prediction.cdc
+++ b/transactions/place_prediction.cdc
@@ -18,11 +18,11 @@ transaction(marketId: UInt64, option: String, amount: UFix64) {
     let predictionPaymentVault: @FungibleToken.Vault
     let predictorAddress: Address
 
-    prepare(signer: AuthAccount) {
+    prepare(signer: auth(Storage) &Account) {
         self.predictorAddress = signer.address
 
         let vaultRef = signer.storage.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)
-            ?? panic("Could not borrow reference to the signer's FlowToken Vault")
+            ?? panic(message: "Could not borrow reference to the signer's FlowToken Vault")
 
         assert(vaultRef.balance >= amount, message: "Insufficient FLOW balance for this prediction amount.")
         self.predictionPaymentVault <- vaultRef.withdraw(amount: amount)

--- a/transactions/remove_admin.cdc
+++ b/transactions/remove_admin.cdc
@@ -14,11 +14,11 @@ transaction(adminToRemoveAddress: Address) {
 
     let callingAdminCapability: &FlowWager.AdminCapability
 
-    prepare(signer: AuthAccount) {
+    prepare(signer: auth(Storage) &Account) {
         // Borrow the calling admin's capability from their account.
         // Assumes admins store their capability at /storage/flowWagerAdminCapability.
         self.callingAdminCapability = signer.storage.borrow<&FlowWager.AdminCapability>(from: /storage/flowWagerAdminCapability)
-            ?? panic("Could not borrow AdminCapability from signer. Ensure you are an admin and the capability is at the correct path.")
+            ?? panic(message: "Could not borrow AdminCapability from signer. Ensure you are an admin and the capability is at the correct path.")
 
         // The FlowWager.removeAdmin function itself performs permission and other necessary checks.
     }

--- a/transactions/resolve_market.cdc
+++ b/transactions/resolve_market.cdc
@@ -15,11 +15,11 @@ transaction(marketId: UInt64, outcome: String, evidenceURL: String) {
 
     let adminCapability: &FlowWager.AdminCapability
 
-    prepare(signer: AuthAccount) {
+    prepare(signer: auth(Storage) &Account) {
         // Borrow the admin capability from the signer's account.
         // Assumes admins store their capability at /storage/flowWagerAdminCapability.
         self.adminCapability = signer.storage.borrow<&FlowWager.AdminCapability>(from: /storage/flowWagerAdminCapability)
-            ?? panic("Could not borrow AdminCapability from signer. Ensure you are an admin and the capability is at the correct path.")
+            ?? panic(message: "Could not borrow AdminCapability from signer. Ensure you are an admin and the capability is at the correct path.")
 
         // The FlowWager.resolveMarket function itself performs permission checks.
     }

--- a/transactions/update_market_status.cdc
+++ b/transactions/update_market_status.cdc
@@ -19,9 +19,10 @@ transaction(marketId: UInt64) {
     //     // TODO: Consider emitting MarketStatusUpdated event here or ensure trySetToPendingResolution does.
     // }
 
-    prepare(signer: AuthAccount) {
+    prepare(signer: &Account) {
         // No specific signer state needed for this transaction as anyone can trigger it,
-        // provided the target `triggerMarketStatusUpdate` function is public.
+        // if the target `triggerMarketStatusUpdate` function is public and doesn't require auth.
+        // Using &Account as the most basic form of signer.
     }
 
     execute {

--- a/transactions/withdraw_platform_fees.cdc
+++ b/transactions/withdraw_platform_fees.cdc
@@ -18,15 +18,17 @@ transaction(amount: UFix64, recipientAddress: Address) {
     let callingAdminCapability: &FlowWager.AdminCapability
     let feeReceiver: &{FungibleToken.Receiver}
 
-    prepare(signer: AuthAccount) {
+    prepare(signer: auth(Storage) &Account) { // auth(Storage) for signer.storage.borrow
         self.callingAdminCapability = signer.storage.borrow<&FlowWager.AdminCapability>(from: /storage/flowWagerAdminCapability)
-            ?? panic("Could not borrow AdminCapability from signer. Ensure you are an admin and the capability is at the correct path.")
+            ?? panic(message: "Could not borrow AdminCapability from signer. Ensure you are an admin and the capability is at the correct path.")
 
         // Get the public Receiver capability for the recipient address.
         // Assumes standard /public/flowTokenReceiver path.
-        self.feeReceiver = getAccount(recipientAddress)
-            .capabilities.borrow<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)
-            ?? panic("Could not borrow Receiver capability for the recipient. Ensure it's published at /public/flowTokenReceiver.")
+        // getAccount().capabilities.borrow requires auth(Capabilities) on the account being called, not the signer.
+        // However, the getAccount(recipientAddress) itself does not require signer authorization.
+        let recipientAccount = getAccount(recipientAddress)
+        self.feeReceiver = recipientAccount.capabilities.borrow<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)
+            ?? panic(message: "Could not borrow Receiver capability for the recipient. Ensure it's published at /public/flowTokenReceiver.")
     }
 
     execute {


### PR DESCRIPTION
- Changed relative contract imports to named imports (e.g., "FlowWagerTypes").
- Removed all uses of `destroy` keyword and custom resource destructors.
- Updated transaction `prepare` phases from `AuthAccount` to `auth(...) &Account`.
- Replaced `pub` access modifier with `access(all)`.
- Updated `panic()` calls to use the `message:` argument label.
- Replaced array `.join()` and `.toString()` for logging with manual loops.
- Added `MarketResolutionInfo` struct to `FlowWagerTypes.cdc` and updated `batch_resolve_markets.cdc` transaction.
- Reviewed and confirmed enum definitions align with Cadence 1.0 accessibility.